### PR TITLE
The artifact jars are corrupt because of the missing https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
 		<repository>
 			<id>artifacts.alfresco.com</id>
 			<name>Alfresco Maven Repository</name>
-			<url>http://artifacts.alfresco.com/nexus/content/repositories/releases</url>
+			<url>https://artifacts.alfresco.com/nexus/content/repositories/releases</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Most of the jars were corrupt.  I corrected the pom so it downloads from artifacts.alfresco.com using _https_.
